### PR TITLE
feat!: migrate to constructs v10

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -25,6 +25,7 @@
     },
     {
       "name": "constructs",
+      "version": "10.0.0",
       "type": "build"
     },
     {
@@ -101,6 +102,7 @@
     },
     {
       "name": "constructs",
+      "version": "^10",
       "type": "peer"
     }
   ],

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -6,12 +6,12 @@ const project = new cdk.JsiiProject({
   description: 'Basic implementation of a Redis construct for cdk8s.',
   repository: 'https://github.com/cdk8s-team/cdk8s-redis.git',
   authorName: 'Amazon Web Services',
-  authorEmail: 'https://aws.amazon.com',
+  authorUrl: 'https://aws.amazon.com',
   stability: 'experimental',
   projenUpgradeSecret: 'PROJEN_GITHUB_TOKEN',
   peerDeps: [
     'cdk8s',
-    'constructs',
+    'constructs@^10',
   ],
   keywords: [
     'cdk8s',

--- a/API.md
+++ b/API.md
@@ -19,7 +19,7 @@ Name|Description
 
 
 
-__Implements__: [IConstruct](#constructs-iconstruct)
+__Implements__: [IConstruct](#constructs-iconstruct), [IDependable](#constructs-idependable)
 __Extends__: [Construct](#constructs-construct)
 
 ### Initializer

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "author": {
     "name": "Amazon Web Services",
-    "email": "https://aws.amazon.com",
+    "url": "https://aws.amazon.com",
     "organization": false
   },
   "devDependencies": {
@@ -36,8 +36,8 @@
     "@types/node": "^12",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
-    "cdk8s": "^1.2.11",
-    "constructs": "^3.3.165",
+    "cdk8s": "^1.3.0",
+    "constructs": "10.0.0",
     "eslint": "^8",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-import-resolver-typescript": "^2.5.0",
@@ -56,8 +56,8 @@
     "typescript": "^4.5.4"
   },
   "peerDependencies": {
-    "cdk8s": "^1.2.11",
-    "constructs": "^3.3.165"
+    "cdk8s": "^1.3.0",
+    "constructs": "^10"
   },
   "bundledDependencies": [],
   "keywords": [

--- a/src/service-deployment.ts
+++ b/src/service-deployment.ts
@@ -75,7 +75,7 @@ export class ServiceDeployment extends Construct {
 
     const label = {
       ...options.labels,
-      app: Node.of(this).uniqueId,
+      app: `${id}${Node.of(this).addr}`,
     };
 
     const service = new k8s.Service(this, 'service', {

--- a/test/__snapshots__/redis.test.ts.snap
+++ b/test/__snapshots__/redis.test.ts.snap
@@ -7,7 +7,7 @@ Array [
     "kind": "Service",
     "metadata": Object {
       "labels": Object {
-        "app": "testredisprimary745D4B4B",
+        "app": "primaryc8b2fe46a20ee748f914a8b108427882c2c06096a9",
         "role": "primary",
       },
       "name": "test-redis-primary-service-c8f36e4b",
@@ -20,7 +20,7 @@ Array [
         },
       ],
       "selector": Object {
-        "app": "testredisprimary745D4B4B",
+        "app": "primaryc8b2fe46a20ee748f914a8b108427882c2c06096a9",
         "role": "primary",
       },
       "type": "ClusterIP",
@@ -36,14 +36,14 @@ Array [
       "replicas": 1,
       "selector": Object {
         "matchLabels": Object {
-          "app": "testredisprimary745D4B4B",
+          "app": "primaryc8b2fe46a20ee748f914a8b108427882c2c06096a9",
           "role": "primary",
         },
       },
       "template": Object {
         "metadata": Object {
           "labels": Object {
-            "app": "testredisprimary745D4B4B",
+            "app": "primaryc8b2fe46a20ee748f914a8b108427882c2c06096a9",
             "role": "primary",
           },
         },
@@ -80,7 +80,7 @@ Array [
     "kind": "Service",
     "metadata": Object {
       "labels": Object {
-        "app": "testredisreplicaCE5FD4D7",
+        "app": "replicac8dfe5fbb37f49bc8b747fb7ebdee0549ee0d2cbc0",
         "role": "replica",
       },
       "name": "test-redis-replica-service-c814a5a4",
@@ -93,7 +93,7 @@ Array [
         },
       ],
       "selector": Object {
-        "app": "testredisreplicaCE5FD4D7",
+        "app": "replicac8dfe5fbb37f49bc8b747fb7ebdee0549ee0d2cbc0",
         "role": "replica",
       },
       "type": "ClusterIP",
@@ -109,14 +109,14 @@ Array [
       "replicas": 2,
       "selector": Object {
         "matchLabels": Object {
-          "app": "testredisreplicaCE5FD4D7",
+          "app": "replicac8dfe5fbb37f49bc8b747fb7ebdee0549ee0d2cbc0",
           "role": "replica",
         },
       },
       "template": Object {
         "metadata": Object {
           "labels": Object {
-            "app": "testredisreplicaCE5FD4D7",
+            "app": "replicac8dfe5fbb37f49bc8b747fb7ebdee0549ee0d2cbc0",
             "role": "replica",
           },
         },
@@ -162,7 +162,7 @@ Array [
     "kind": "Service",
     "metadata": Object {
       "labels": Object {
-        "app": "testredisprimary745D4B4B",
+        "app": "primaryc8b2fe46a20ee748f914a8b108427882c2c06096a9",
         "role": "primary",
       },
       "name": "test-redis-primary-service-c8f36e4b",
@@ -175,7 +175,7 @@ Array [
         },
       ],
       "selector": Object {
-        "app": "testredisprimary745D4B4B",
+        "app": "primaryc8b2fe46a20ee748f914a8b108427882c2c06096a9",
         "role": "primary",
       },
       "type": "ClusterIP",
@@ -191,14 +191,14 @@ Array [
       "replicas": 1,
       "selector": Object {
         "matchLabels": Object {
-          "app": "testredisprimary745D4B4B",
+          "app": "primaryc8b2fe46a20ee748f914a8b108427882c2c06096a9",
           "role": "primary",
         },
       },
       "template": Object {
         "metadata": Object {
           "labels": Object {
-            "app": "testredisprimary745D4B4B",
+            "app": "primaryc8b2fe46a20ee748f914a8b108427882c2c06096a9",
             "role": "primary",
           },
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1377,10 +1377,10 @@ case@^1.6.3:
   resolved "https://registry.yarnpkg.com/case/-/case-1.6.3.tgz#0a4386e3e9825351ca2e6216c60467ff5f1ea1c9"
   integrity sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==
 
-cdk8s@^1.2.11:
-  version "1.2.11"
-  resolved "https://registry.yarnpkg.com/cdk8s/-/cdk8s-1.2.11.tgz#fd6d5bcc5f13ee403cdce35457d04c8f3543ac8f"
-  integrity sha512-x1Z+BZa6mLtBr5Nr0zNvSkAHvtyC/zNTWOOxwXXsGy3vd8wjgwotTIwZf1pDPwmchA73DppBXgXI+0XeGBjD8g==
+cdk8s@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/cdk8s/-/cdk8s-1.3.0.tgz#146be69204999789afda8665b4ff8fb3cf79be57"
+  integrity sha512-pCdi6TiImtd6WIX2YZ+oTz3JAJ1jwJr5ODS5FiR28n1ZoFTqxaOMZ3y1/5UxRlRWje1bVKQfVTxksGlO1yxKlw==
   dependencies:
     fast-json-patch "^2.2.1"
     follow-redirects "^1.14.6"
@@ -1618,10 +1618,10 @@ console-control-strings@^1.0.0, console-control-strings@^1.1.0:
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
-constructs@^3.3.165:
-  version "3.3.165"
-  resolved "https://registry.yarnpkg.com/constructs/-/constructs-3.3.165.tgz#7ba4f5ef344ec2ed13357021747f0e412a363d76"
-  integrity sha512-s1O0hXAVDNhwCk07vM7Av9Xek3EUF8LdvVRaFSk+oONp/A5cPGz0fXFJkp0fg9JF34imWr20F2uCggw1t8ozhw==
+constructs@10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.0.0.tgz#a6d498540111f6d75663711d0fa65f32fc8f1786"
+  integrity sha512-MIwjmrXZpM9RtwyrSD4HotDIQl8HTdIefQhU+MU1asvtSyVN3kK8kjeUOWMFb+fdyT4RX3QvvcaaPBluLEX1SA==
 
 conventional-changelog-angular@^5.0.12:
   version "5.0.13"


### PR DESCRIPTION
BREAKING CHANGE: cdk8s-redis now only supports v10 of the `constructs` framework. If you wish to use it with constructs v3, you should keep your dependency pinned to cdk8s-redis v0.1.x.

Signed-off-by: Christopher Rybicki <rybickic@amazon.com>