### PR TITLE
fix: migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/src/redis.ts
+++ b/src/redis.ts
@@ -30,7 +30,7 @@ export class Redis extends Construct {
     super(scope, id);
 
     const primary = new ServiceDeployment(this, 'primary', {
-      image: 'k8s.gcr.io/redis:e2e',
+      image: 'registry.k8s.io/redis:e2e',
       containerPort: 6379,
       externalPort: 6379,
       containerName: 'primary',

--- a/test/__snapshots__/redis.test.ts.snap
+++ b/test/__snapshots__/redis.test.ts.snap
@@ -56,7 +56,7 @@ Array [
                   "value": "dns",
                 },
               ],
-              "image": "k8s.gcr.io/redis:e2e",
+              "image": "registry.k8s.io/redis:e2e",
               "name": "primary",
               "ports": Array [
                 Object {
@@ -211,7 +211,7 @@ Array [
                   "value": "dns",
                 },
               ],
-              "image": "k8s.gcr.io/redis:e2e",
+              "image": "registry.k8s.io/redis:e2e",
               "name": "primary",
               "ports": Array [
                 Object {


### PR DESCRIPTION
This fix is a part of an umbrella issue https://github.com/kubernetes/k8s.io/issues/4780